### PR TITLE
If the dependency-check report is missing, skip check without any error.

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
@@ -170,7 +170,10 @@ public class DependencyCheckSensor implements Sensor {
             totalDependencies = analysis.getDependencies().size();
             addIssues(context, project, analysis);
         } catch (Exception e) {
-            throw new RuntimeException("Can not process Dependency-Check report.", e);
+            //If the dependency-Check report doesn't exists, don't log a additional warning.
+            if(!(e instanceof FileNotFoundException)){
+                LOGGER.error("Can not process Dependency-Check report.", e);
+            }
         } finally {
             profiler.stopInfo();
         }


### PR DESCRIPTION
We have many projects on our sonar server. Whit this plugin, all project without dependency-check fails.
With this pull request the analysis don't fail if the dependency-Check report file is missing. Any other error are just logged.
