### PR TITLE
Revert "If the dependency-check report is missing, skip check without any error."

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
@@ -184,10 +184,7 @@ public class DependencyCheckSensor implements Sensor {
         } catch (FileNotFoundException e) {
             LOGGER.debug("Analysis aborted due to missing report file", e);
         } catch (Exception e) {
-            //If the dependency-Check report doesn't exists, don't log a additional warning.
-            if(!(e instanceof FileNotFoundException)){
-                LOGGER.error("Can not process Dependency-Check report.", e);
-            }
+            throw new RuntimeException("Can not process Dependency-Check report.", e);
         } finally {
             profiler.stopInfo();
         }


### PR DESCRIPTION
Reverts stevespringett/dependency-check-sonar-plugin#33