### PR TITLE
Adding embedded HTML report for OWASP Dependency-Check

### DIFF
--- a/sonar-dependency-check-plugin/pom.xml
+++ b/sonar-dependency-check-plugin/pom.xml
@@ -13,7 +13,7 @@
     <url>https://www.owasp.org/index.php/OWASP_Dependency_Check</url>
 
     <properties>
-        <sonar.version>6.0</sonar.version>
+        <sonar.version>6.3</sonar.version>
         <!-- Configuration for sonar-packaging-maven-plugin -->
         <sonar.pluginClass>org.sonar.dependencycheck.DependencyCheckPlugin</sonar.pluginClass>
         <sonar.pluginName>Dependency-Check</sonar.pluginName>

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckPlugin.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckPlugin.java
@@ -23,6 +23,7 @@ import org.sonar.api.Plugin;
 import org.sonar.api.config.PropertyDefinition;
 import org.sonar.dependencycheck.base.DependencyCheckConstants;
 import org.sonar.dependencycheck.base.DependencyCheckMetrics;
+import org.sonar.dependencycheck.page.DependencyCheckReportPage;
 import org.sonar.dependencycheck.rule.KnownCveRuleDefinition;
 import org.sonar.dependencycheck.rule.NeutralLanguage;
 import org.sonar.dependencycheck.rule.NeutralProfile;
@@ -42,13 +43,19 @@ public final class DependencyCheckPlugin implements Plugin {
                 NeutralProfile.class,
                 NeutralLanguage.class,
                 KnownCveRuleDefinition.class,
-                DependencyCheckWidget.class);
+                DependencyCheckWidget.class,
+                DependencyCheckReportPage.class);
 
-        context.addExtension(
+        context.addExtensions(
                 PropertyDefinition.builder(DependencyCheckConstants.REPORT_PATH_PROPERTY)
                         .name("Dependency-Check report path")
                         .description("path to the 'dependency-check-report.xml' file")
                         .defaultValue("${WORKSPACE}/dependency-check-report.xml")
+                        .build(),
+                PropertyDefinition.builder(DependencyCheckConstants.HTML_REPORT_PATH_PROPERTY)
+                        .name("Dependency-Check HTML report path")
+                        .description("path to the 'dependency-check-report.html' file")
+                        .defaultValue("${WORKSPACE}/dependency-check-report.html")
                         .build()
         );
     }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckMetrics.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckMetrics.java
@@ -39,6 +39,7 @@ public final class DependencyCheckMetrics implements Metrics {
     private static final String HIGH_SEVERITY_VULNS_KEY = "high_severity_vulns";
     private static final String MEDIUM_SEVERITY_VULNS_KEY = "medium_severity_vulns";
     private static final String LOW_SEVERITY_VULNS_KEY = "low_severity_vulns";
+    private static final String REPORT_KEY = "report";
 
     public static final Metric<Serializable> INHERITED_RISK_SCORE = new Metric.Builder(DependencyCheckMetrics.INHERITED_RISK_SCORE_KEY, "Inherited Risk Score", Metric.ValueType.INT)
             .setDescription("Inherited Risk Score")
@@ -109,6 +110,13 @@ public final class DependencyCheckMetrics implements Metrics {
             .setHidden(false)
             .create();
 
+    public static final Metric<Serializable> REPORT = new Metric.Builder(REPORT_KEY, "OWASP Dependency-Check Report", Metric.ValueType.DATA)
+            .setDescription("Report HTML")
+            .setQualitative(false)
+            .setDomain(DependencyCheckMetrics.DOMAIN)
+            .setHidden(false)
+            .create();
+
     public static double vulnerableComponentRatio(int vulnerabilities, int vulnerableComponents) {
         double ratio = 0.0;
         if(vulnerableComponents > 0) {
@@ -132,7 +140,8 @@ public final class DependencyCheckMetrics implements Metrics {
                 DependencyCheckMetrics.LOW_SEVERITY_VULNS,
                 DependencyCheckMetrics.TOTAL_DEPENDENCIES,
                 DependencyCheckMetrics.VULNERABLE_DEPENDENCIES,
-                DependencyCheckMetrics.TOTAL_VULNERABILITIES
+                DependencyCheckMetrics.TOTAL_VULNERABILITIES,
+                DependencyCheckMetrics.REPORT
         );
     }
 }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/page/DependencyCheckReportPage.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/page/DependencyCheckReportPage.java
@@ -17,14 +17,24 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.dependencycheck.base;
+package org.sonar.dependencycheck.page;
 
-public final class DependencyCheckConstants {
+import org.sonar.api.web.page.Context;
+import org.sonar.api.web.page.Page;
+import org.sonar.api.web.page.Page.Scope;
+import org.sonar.api.web.page.PageDefinition;
 
-    public static final String REPORT_PATH_PROPERTY = "sonar.dependencyCheck.reportPath";
-    public static final String HTML_REPORT_PATH_PROPERTY = "sonar.dependencyCheck.htmlReportPath";
+public class DependencyCheckReportPage implements PageDefinition {
 
-    private DependencyCheckConstants() {
-    }
+	@Override
+	public void define(Context context) {
+		context.addPage(
+				Page.builder("dependencycheck/report")
+				.setScope(Scope.COMPONENT)
+				.setComponentQualifiers(Page.Qualifier.PROJECT)
+				.setName("OWASP Dependency-Check")
+				.setAdmin(false).build());
+		
+	}
 
 }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/page/package-info.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/page/package-info.java
@@ -17,14 +17,5 @@
  * along with this program; if not, write to the Free Software Foundation,
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
-package org.sonar.dependencycheck.base;
 
-public final class DependencyCheckConstants {
-
-    public static final String REPORT_PATH_PROPERTY = "sonar.dependencyCheck.reportPath";
-    public static final String HTML_REPORT_PATH_PROPERTY = "sonar.dependencyCheck.htmlReportPath";
-
-    private DependencyCheckConstants() {
-    }
-
-}
+package org.sonar.dependencycheck.page;

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/XmlReportFile.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/XmlReportFile.java
@@ -53,8 +53,8 @@ public class XmlReportFile {
      * @throws org.sonar.api.utils.MessageException if the property relates to a directory or a non-existing file.
      */
     @CheckForNull
-    private File getReportFromProperty() {
-        String path = settings.getString(DependencyCheckConstants.REPORT_PATH_PROPERTY);
+    private File getReportFromProperty(String property) {
+        String path = settings.getString(property);
         if (path == null) {
             return null;
         }
@@ -69,23 +69,23 @@ public class XmlReportFile {
         return report;
     }
 
-    public File getFile() {
+    public File getFile(String property) {
         if (report == null) {
-            report = getReportFromProperty();
+            report = getReportFromProperty(property);
         }
         return report;
     }
 
-    public InputStream getInputStream() throws FileNotFoundException {
-        File reportFile = getFile();
+    public InputStream getInputStream(String property) throws FileNotFoundException {
+        File reportFile = getFile(property);
         if (reportFile == null) {
             throw new FileNotFoundException("Dependency-Check report does not exist.");
         }
         return new FileInputStream(reportFile);
     }
 
-    public boolean exist() {
-        File reportFile = getReportFromProperty();
+    public boolean exist(String property) {
+        File reportFile = getReportFromProperty(property);
         return reportFile != null;
     }
 }

--- a/sonar-dependency-check-plugin/src/main/resources/static/report.js
+++ b/sonar-dependency-check-plugin/src/main/resources/static/report.js
@@ -1,0 +1,33 @@
+window.registerExtension('dependencycheck/report', function(options) {
+	var isDisplayed = true;
+	
+	window.SonarRequest.getJSON('/api/measures/component', {
+		componentKey : options.component.key,
+		metricKeys : 'report'
+	}).then(function(response) {
+		if (isDisplayed) {
+			var htmlString = response.component.measures.filter(measure => measure.metric == 'report')[0].value;
+			var currentEl = options.el;
+			while (currentEl.id !== 'container') {
+				currentEl.style.display = 'flex';
+				currentEl.style.flex = '1 1 auto';
+				currentEl.style.flexDirection = 'column';
+				currentEl = currentEl.parentElement;
+			}
+			currentEl.style.display = 'flex';
+			currentEl.style.flexDirection = 'column';
+			
+			var reportFrame = document.createElement('iframe');
+			reportFrame.sandbox.value = 'allow-scripts allow-same-origin';
+			reportFrame.style.border = 'none';
+			reportFrame.style.flex= '1 1 auto';
+			reportFrame.srcdoc = htmlString;
+			options.el.append(reportFrame);
+		}
+	});
+
+	return function() {
+		options.el.textContent = '';
+		var isDisplayed = false;
+	};
+});


### PR DESCRIPTION
Adds a custom page to the SonarQube report that is an embedded version of the HTML report produced by OWASP Dependency-Check. This allows users easy access to the suppression XML and also to the links to click through to the NVD page about the relevant vulnerability.

Changes / Notes:
- Updated to version 6.3 of SonarQube libraries API (required for support of new features)
- New property for the path of the HTML report, functions similarly to the property for the XML report path property
- Stores the HTML report as a measure of type DATA during analysis, for the new REPORT metric (this new measure does not appear on the measures page with the other 8 measures)
- Custom page uses the API to retrieve and display the report page