### PR TITLE
Embedded Report

### DIFF
--- a/sonar-dependency-check-plugin/src/main/resources/static/report.js
+++ b/sonar-dependency-check-plugin/src/main/resources/static/report.js
@@ -1,21 +1,30 @@
 window.registerExtension('dependencycheck/report', function(options) {
 	var isDisplayed = true;
 	
+	if (!document.querySelector('style#dependency-check-report')) {
+		style = document.createElement("style");
+		style.id = 'dependency-check-report';
+		// WebKit hack :(
+		style.appendChild(document.createTextNode(""));
+		document.head.appendChild(style);
+		style.insertRule(".dependency-check-report-content {flex: 1 1 auto;}", 1);
+		style.insertRule(".dependency-check-report-container {display: flex; flex-direction: column;}", 2);
+	}
+	
 	window.SonarRequest.getJSON('/api/measures/component', {
 		componentKey : options.component.key,
 		metricKeys : 'report'
 	}).then(function(response) {
 		if (isDisplayed) {
 			var htmlString = response.component.measures.filter(measure => measure.metric == 'report')[0].value;
-			var currentEl = options.el;
+			options.el.classList.add('dependency-check-report-content');
+			var currentEl = options.el.parentElement;
 			while (currentEl.id !== 'container') {
-				currentEl.style.display = 'flex';
-				currentEl.style.flex = '1 1 auto';
-				currentEl.style.flexDirection = 'column';
+				currentEl.classList.add('dependency-check-report-content');
+				currentEl.classList.add('dependency-check-report-container');
 				currentEl = currentEl.parentElement;
 			}
-			currentEl.style.display = 'flex';
-			currentEl.style.flexDirection = 'column';
+			currentEl.classList.add('dependency-check-report-container');
 			
 			var reportFrame = document.createElement('iframe');
 			reportFrame.sandbox.value = 'allow-scripts allow-same-origin';
@@ -29,5 +38,13 @@ window.registerExtension('dependencycheck/report', function(options) {
 	return function() {
 		options.el.textContent = '';
 		var isDisplayed = false;
+		options.el.classList.remove('dependency-check-report-content');
+		var currentEl = options.el.parentElement;
+		while (currentEl.id !== 'container') {
+			currentEl.classList.remove('dependency-check-report-content');
+			currentEl.classList.remove('dependency-check-report-container');
+			currentEl = currentEl.parentElement;
+		}
+		currentEl.classList.remove('dependency-check-report-container');
 	};
 });

--- a/sonar-dependency-check-plugin/src/main/resources/static/report.js
+++ b/sonar-dependency-check-plugin/src/main/resources/static/report.js
@@ -1,9 +1,9 @@
 window.registerExtension("dependencycheck/report", function(options) {
 	var isDisplayed = true;
 	
-	if (!document.querySelector('style#dependency-check-report')) {
+	if (!document.querySelector("style#dependency-check-report")) {
 		style = document.createElement("style");
-		style.id = 'dependency-check-report';
+		style.id = "dependency-check-report";
 		// WebKit hack :(
 		style.appendChild(document.createTextNode(""));
 		document.head.appendChild(style);
@@ -11,19 +11,19 @@ window.registerExtension("dependencycheck/report", function(options) {
 		style.sheet.insertRule(".dependency-check-report-container {display: flex; flex-direction: column;}", 0);
 	}
 	
-	window.SonarRequest.getJSON('/api/measures/component', {
+	window.SonarRequest.getJSON("/api/measures/component", {
 		componentKey : options.component.key,
 		metricKeys : "report"
 	}).then(function(response) {
 		if (isDisplayed) {
-			var htmlString = response.component.measures.filter(measure => measure.metric == 'report')[0].value;
+			var htmlString = response.component.measures.filter(measure => measure.metric === "report")[0].value;
 			var currentEl = options.el;
-			while (currentEl.id !== 'container') {
-				currentEl.classList.add('dependency-check-report-content');
-				currentEl.classList.add('dependency-check-report-container');
+			while (currentEl.id !== "container") {
+				currentEl.classList.add("dependency-check-report-content");
+				currentEl.classList.add("dependency-check-report-container");
 				currentEl = currentEl.parentElement;
 			}
-			currentEl.classList.add('dependency-check-report-container');
+			currentEl.classList.add("dependency-check-report-container");
 			
 			var reportFrame = document.createElement("iframe");
 			reportFrame.sandbox.value = "allow-scripts allow-same-origin";
@@ -38,11 +38,11 @@ window.registerExtension("dependencycheck/report", function(options) {
 		options.el.textContent = "";
 		var isDisplayed = false;
 		var currentEl = options.el;
-		while (currentEl.id !== 'container') {
-			currentEl.classList.remove('dependency-check-report-content');
-			currentEl.classList.remove('dependency-check-report-container');
+		while (currentEl.id !== "container") {
+			currentEl.classList.remove("dependency-check-report-content");
+			currentEl.classList.remove("dependency-check-report-container");
 			currentEl = currentEl.parentElement;
 		}
-		currentEl.classList.remove('dependency-check-report-container');
+		currentEl.classList.remove("dependency-check-report-container");
 	};
 });

--- a/sonar-dependency-check-plugin/src/main/resources/static/report.js
+++ b/sonar-dependency-check-plugin/src/main/resources/static/report.js
@@ -2,7 +2,7 @@ window.registerExtension("dependencycheck/report", function(options) {
 	var isDisplayed = true;
 	
 	if (!document.querySelector("style#dependency-check-report")) {
-		style = document.createElement("style");
+		var style = document.createElement("style");
 		style.id = "dependency-check-report";
 		// WebKit hack :(
 		style.appendChild(document.createTextNode(""));

--- a/sonar-dependency-check-plugin/src/main/resources/static/report.js
+++ b/sonar-dependency-check-plugin/src/main/resources/static/report.js
@@ -7,8 +7,8 @@ window.registerExtension("dependencycheck/report", function(options) {
 		// WebKit hack :(
 		style.appendChild(document.createTextNode(""));
 		document.head.appendChild(style);
-		style.insertRule(".dependency-check-report-content {flex: 1 1 auto;}", 1);
-		style.insertRule(".dependency-check-report-container {display: flex; flex-direction: column;}", 2);
+		style.sheet.insertRule(".dependency-check-report-content {flex: 1 1 auto;}", 0);
+		style.sheet.insertRule(".dependency-check-report-container {display: flex; flex-direction: column;}", 0);
 	}
 	
 	window.SonarRequest.getJSON('/api/measures/component', {
@@ -17,8 +17,7 @@ window.registerExtension("dependencycheck/report", function(options) {
 	}).then(function(response) {
 		if (isDisplayed) {
 			var htmlString = response.component.measures.filter(measure => measure.metric == 'report')[0].value;
-			options.el.classList.add('dependency-check-report-content');
-			var currentEl = options.el.parentElement;
+			var currentEl = options.el;
 			while (currentEl.id !== 'container') {
 				currentEl.classList.add('dependency-check-report-content');
 				currentEl.classList.add('dependency-check-report-container');
@@ -38,8 +37,7 @@ window.registerExtension("dependencycheck/report", function(options) {
 	return function() {
 		options.el.textContent = "";
 		var isDisplayed = false;
-		options.el.classList.remove('dependency-check-report-content');
-		var currentEl = options.el.parentElement;
+		var currentEl = options.el;
 		while (currentEl.id !== 'container') {
 			currentEl.classList.remove('dependency-check-report-content');
 			currentEl.classList.remove('dependency-check-report-container');


### PR DESCRIPTION
The previous version of the embedded report added flex display styling to some html elements that did not belong to the custom page - this was necessary to allow the report content to stretch to take up available space. However, when going to other pages, the styles remained, causing display issues.

This refactor switches to using classes to apply the styles, and cleans up after itself by removing the classes when navigating to other pages.