### PR TITLE
work-around for issue #55

### DIFF
--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
@@ -22,6 +22,7 @@ package org.sonar.dependencycheck;
 import org.apache.commons.lang3.StringUtils;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.TextRange;
 import org.sonar.api.batch.rule.Severity;
 import org.sonar.api.batch.sensor.Sensor;
 import org.sonar.api.batch.sensor.SensorContext;
@@ -72,12 +73,19 @@ public class DependencyCheckSensor implements Sensor {
         this.pathResolver = pathResolver;
     }
 
-    private void addIssue(SensorContext context, Dependency dependency, Vulnerability vulnerability) {
+    private void addIssue(SensorContext context, InputFile reportFile, Dependency dependency, Vulnerability vulnerability) {
+
+        TextRange artificialTextRange = reportFile.selectLine(vulnerability.getLineNumer());
+        LOGGER.debug("TextRange: '{}' for dependency: '{}' and vulnerability: '{}'", artificialTextRange,
+                dependency.getFileName(), vulnerability.getName());
+
         Severity severity = DependencyCheckUtils.cvssToSonarQubeSeverity(vulnerability.getCvssScore(), context.settings().getDouble(DependencyCheckConstants.SEVERITY_CRITICAL), context.settings().getDouble(DependencyCheckConstants.SEVERITY_MAJOR));
+
         context.newIssue()
                 .forRule(RuleKey.of(DependencyCheckPlugin.REPOSITORY_KEY, DependencyCheckPlugin.RULE_KEY))
                 .at(new DefaultIssueLocation()
-                        .on(context.module())
+                        .on(reportFile)
+                        .at(artificialTextRange)
                         .message(formatDescription(dependency, vulnerability))
                 )
                 .overrideSeverity(severity)
@@ -123,11 +131,19 @@ public class DependencyCheckSensor implements Sensor {
             return;
         }
         for (Dependency dependency : analysis.getDependencies()) {
+            LOGGER.debug("Processing dependency '{}', filePath: '{}'", dependency.getFileName(), dependency.getFilePath());
             InputFile testFile = fileSystem.inputFile(
                     fileSystem.predicates().hasPath(
                             escapeReservedPathChars(dependency.getFilePath())
                     )
             );
+
+            String reportFilePath = context.settings().getString(DependencyCheckConstants.REPORT_PATH_PROPERTY);
+            InputFile reportFile = fileSystem.inputFile(fileSystem.predicates().hasPath(reportFilePath));
+            if (null == reportFile) {
+                LOGGER.warn("skipping dependency '{}' as no inputFile could established.", dependency.getFileName());
+                return;
+            }
 
             int depVulnCount = dependency.getVulnerabilities().size();
 
@@ -139,7 +155,7 @@ public class DependencyCheckSensor implements Sensor {
             saveMetricOnFile(context, testFile, DependencyCheckMetrics.TOTAL_DEPENDENCIES, (double) depVulnCount);
 
             for (Vulnerability vulnerability : dependency.getVulnerabilities()) {
-                addIssue(context, dependency, vulnerability);
+                addIssue(context, reportFile, dependency, vulnerability);
                 vulnerabilityCount++;
             }
         }
@@ -158,7 +174,7 @@ public class DependencyCheckSensor implements Sensor {
         	return new ReportParser().parse(stream);
         }
     }
-    
+
 	private String getHtmlReport(SensorContext context) {
 		XmlReportFile report = new XmlReportFile(context.settings(), fileSystem, this.pathResolver);
 		File reportFile = report.getFile(DependencyCheckConstants.HTML_REPORT_PATH_PROPERTY);

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/ReportParser.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/ReportParser.java
@@ -105,6 +105,7 @@ public class ReportParser {
 
     private Vulnerability processVulnerability(SMInputCursor vulnC) throws XMLStreamException {
         Vulnerability vulnerability = new Vulnerability();
+        vulnerability.setLineNumer(vulnC.getLocation().getLineNumber());
         SMInputCursor childCursor = vulnC.childCursor();
         while (childCursor.getNext() != null) {
             String nodeName = childCursor.getLocalName();

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Vulnerability.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/parser/element/Vulnerability.java
@@ -26,6 +26,7 @@ public class Vulnerability {
     private String severity;
     private String description;
     private String cwe;
+    private int lineNumer;
 
     public String getName() {
         return name;
@@ -65,6 +66,14 @@ public class Vulnerability {
 
     public void setCwe(String cwe) {
         this.cwe = cwe;
+    }
+
+    public int getLineNumer() {
+        return lineNumer;
+    }
+
+    public void setLineNumer(int lineNumer) {
+        this.lineNumer = lineNumer;
     }
 
 }

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/DependencyCheckSensorTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/parser/DependencyCheckSensorTest.java
@@ -21,8 +21,11 @@ package org.sonar.dependencycheck.parser;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.sonar.api.batch.fs.FilePredicate;
 import org.sonar.api.batch.fs.FileSystem;
 import org.sonar.api.batch.fs.InputComponent;
+import org.sonar.api.batch.fs.InputFile;
+import org.sonar.api.batch.fs.internal.DefaultInputFile;
 import org.sonar.api.batch.measure.Metric;
 import org.sonar.api.batch.sensor.SensorContext;
 import org.sonar.api.batch.sensor.SensorDescriptor;
@@ -76,6 +79,12 @@ public class DependencyCheckSensorTest {
 
         when(context.settings().getString(DependencyCheckConstants.REPORT_PATH_PROPERTY)).thenReturn("dependency-check-report.xml");
         when(pathResolver.relativeFile(any(File.class), anyString())).thenReturn(sampleReport);
+
+        InputFile mockInputFile = mock(DefaultInputFile.class);
+        when(fileSystem.inputFile(any(FilePredicate.class))).thenReturn(mockInputFile);
+        when(mockInputFile.isFile()).thenReturn(true);
+
+
         sensor.execute(context);
     }
 
@@ -94,6 +103,11 @@ public class DependencyCheckSensorTest {
 
         when(context.settings().getString(DependencyCheckConstants.REPORT_PATH_PROPERTY)).thenReturn("dependency-check-report.xml");
         when(pathResolver.relativeFile(any(File.class), anyString())).thenReturn(sampleReport);
+
+        InputFile mockInputFile = mock(DefaultInputFile.class);
+        when(fileSystem.inputFile(any(FilePredicate.class))).thenReturn(mockInputFile);
+        when(mockInputFile.isFile()).thenReturn(true);
+
         sensor.execute(context);
 
         verify(context, times(3)).newIssue();
@@ -105,6 +119,11 @@ public class DependencyCheckSensorTest {
 
         when(context.settings().getString(DependencyCheckConstants.REPORT_PATH_PROPERTY)).thenReturn("dependency-check-report.xml");
         when(pathResolver.relativeFile(any(File.class), anyString())).thenReturn(sampleReport);
+
+        InputFile mockInputFile = mock(DefaultInputFile.class);
+        when(fileSystem.inputFile(any(FilePredicate.class))).thenReturn(mockInputFile);
+        when(mockInputFile.isFile()).thenReturn(true);
+
         sensor.execute(context);
 
         verify(context.newMeasure(), times(8)).forMetric(any(Metric.class));
@@ -116,6 +135,11 @@ public class DependencyCheckSensorTest {
 
         when(context.settings().getString(DependencyCheckConstants.REPORT_PATH_PROPERTY)).thenReturn("dependency-check-report.xml");
         when(pathResolver.relativeFile(any(File.class), anyString())).thenReturn(sampleReport);
+
+        InputFile mockInputFile = mock(DefaultInputFile.class);
+        when(fileSystem.inputFile(any(FilePredicate.class))).thenReturn(mockInputFile);
+        when(mockInputFile.isFile()).thenReturn(true);
+
         sensor.execute(context);
 
         verify(context.newMeasure(), atLeastOnce()).on(any(InputComponent.class));


### PR DESCRIPTION
This is just a proof-of-concept implementation, meant to support my supposition: it indicates, that issue #55 is caused by invalid comparison strategies in SonarQube. 

This work-around solution uses dependency-check-report.xml as input component to report the issues on. That way there is a sensible line number that can be attached to each issue, thus circumventing the sorting issue.