### PR TITLE
Severity minor configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ To configure the severity of the created issues you can optionally specify the m
 ```ini
 sonar.dependencyCheck.severity.critical=7.0
 sonar.dependencyCheck.severity.major=4.0
+sonar.dependencyCheck.severity.minor=0.0
 ```
 
 Ecosystem

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckPlugin.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckPlugin.java
@@ -73,6 +73,13 @@ public final class DependencyCheckPlugin implements Plugin {
                         .description("Minimum score for major issues or -1 to deactivate major issues.")
                         .defaultValue("4.0")
                         .type(PropertyType.FLOAT)
+                        .build(),
+                PropertyDefinition.builder(DependencyCheckConstants.SEVERITY_MINOR)
+                        .subCategory("Severities")
+                        .name("Minor")
+                        .description("Minimum score for minor issues or -1 to deactivate minor issues.")
+                        .defaultValue("0.0")
+                        .type(PropertyType.FLOAT)
                         .build()
         );
     }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/DependencyCheckSensor.java
@@ -79,7 +79,7 @@ public class DependencyCheckSensor implements Sensor {
         LOGGER.debug("TextRange: '{}' for dependency: '{}' and vulnerability: '{}'", artificialTextRange,
                 dependency.getFileName(), vulnerability.getName());
 
-        Severity severity = DependencyCheckUtils.cvssToSonarQubeSeverity(vulnerability.getCvssScore(), context.settings().getDouble(DependencyCheckConstants.SEVERITY_CRITICAL), context.settings().getDouble(DependencyCheckConstants.SEVERITY_MAJOR));
+        Severity severity = DependencyCheckUtils.cvssToSonarQubeSeverity(vulnerability.getCvssScore(), context.settings().getDouble(DependencyCheckConstants.SEVERITY_CRITICAL), context.settings().getDouble(DependencyCheckConstants.SEVERITY_MAJOR), context.settings().getDouble(DependencyCheckConstants.SEVERITY_MINOR));
 
         context.newIssue()
                 .forRule(RuleKey.of(DependencyCheckPlugin.REPOSITORY_KEY, DependencyCheckPlugin.RULE_KEY))

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckConstants.java
@@ -25,6 +25,7 @@ public final class DependencyCheckConstants {
     public static final String HTML_REPORT_PATH_PROPERTY = "sonar.dependencyCheck.htmlReportPath";
     public static final String SEVERITY_CRITICAL = "sonar.dependencyCheck.severity.critical";
     public static final String SEVERITY_MAJOR = "sonar.dependencyCheck.severity.major";
+    public static final String SEVERITY_MINOR = "sonar.dependencyCheck.severity.minor";
 
     private DependencyCheckConstants() {
     }

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
@@ -39,14 +39,16 @@ public final class DependencyCheckUtils {
         return new SMInputFactory(xmlFactory);
     }
 
-    public static Severity cvssToSonarQubeSeverity(String cvssScore, Double critical, Double major) {
+    public static Severity cvssToSonarQubeSeverity(String cvssScore, Double critical, Double major, Double minor) {
         double score = Double.parseDouble(cvssScore);
         if (critical.doubleValue() >= 0 && score >= critical.doubleValue()) {
             return Severity.CRITICAL;
         } else if (major.doubleValue() >= 0 && score >= major.doubleValue()) {
             return Severity.MAJOR;
-        } else {
+        } else if (minor.doubleValue() >= 0 && score >= minor.doubleValue()) {
             return Severity.MINOR;
+        } else {
+            return Severity.INFO;
         }
     }
 

--- a/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
+++ b/sonar-dependency-check-plugin/src/main/java/org/sonar/dependencycheck/base/DependencyCheckUtils.java
@@ -41,9 +41,9 @@ public final class DependencyCheckUtils {
 
     public static Severity cvssToSonarQubeSeverity(String cvssScore, Double critical, Double major) {
         double score = Double.parseDouble(cvssScore);
-        if (critical.doubleValue() > 0 && score >= critical.doubleValue()) {
+        if (critical.doubleValue() >= 0 && score >= critical.doubleValue()) {
             return Severity.CRITICAL;
-        } else if (major.doubleValue() > 0 && score >= major.doubleValue()) {
+        } else if (major.doubleValue() >= 0 && score >= major.doubleValue()) {
             return Severity.MAJOR;
         } else {
             return Severity.MINOR;

--- a/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/base/DependencyCheckUtilsTest.java
+++ b/sonar-dependency-check-plugin/src/test/java/org/sonar/dependencycheck/base/DependencyCheckUtilsTest.java
@@ -35,58 +35,96 @@ public class DependencyCheckUtilsTest {
     private final String cvssSeverity;
     private final Double critical;
     private final Double major;
+    private final Double minor;
     private final Severity expectedSeverity;
 
-    public DependencyCheckUtilsTest(String cvssSeverity, Double critical, Double major, Severity expectedSeverity) {
+    public DependencyCheckUtilsTest(String cvssSeverity, Double critical, Double major, Double minor, Severity expectedSeverity) {
         this.cvssSeverity = cvssSeverity;
         this.critical = critical;
         this.major = major;
+        this.minor = minor;
         this.expectedSeverity = expectedSeverity;
     }
 
     @Parameterized.Parameters
     public static Collection<Object[]> severities() {
         return Arrays.asList(new Object[][]{
-        	        // defaults
-                {"10.0", Double.valueOf("7.0"), Double.valueOf("4.0"), Severity.CRITICAL},
-                {"7.0",  Double.valueOf("7.0"), Double.valueOf("4.0"), Severity.CRITICAL},
-                {"6.9",  Double.valueOf("7.0"), Double.valueOf("4.0"), Severity.MAJOR},
-                {"4.0",  Double.valueOf("7.0"), Double.valueOf("4.0"), Severity.MAJOR},
-                {"3.9",  Double.valueOf("7.0"), Double.valueOf("4.0"), Severity.MINOR},
-                {"0.0",  Double.valueOf("7.0"), Double.valueOf("4.0"), Severity.MINOR},
-                
-    	            // custom
-                {"10.0", Double.valueOf("5.0"), Double.valueOf("2.0"), Severity.CRITICAL},
-                {"7.0",  Double.valueOf("5.0"), Double.valueOf("2.0"), Severity.CRITICAL},
-                {"6.9",  Double.valueOf("5.0"), Double.valueOf("2.0"), Severity.CRITICAL},
-                {"4.0",  Double.valueOf("5.0"), Double.valueOf("2.0"), Severity.MAJOR},
-                {"3.9",  Double.valueOf("5.0"), Double.valueOf("2.0"), Severity.MAJOR},
-                {"1.9",  Double.valueOf("5.0"), Double.valueOf("2.0"), Severity.MINOR},
-                {"0.0",  Double.valueOf("5.0"), Double.valueOf("2.0"), Severity.MINOR},
-                
-	            // custom, critical deactivated
-                {"10.0", Double.valueOf("-1"),  Double.valueOf("2.0"), Severity.MAJOR},
-                {"7.0",  Double.valueOf("-1"),  Double.valueOf("2.0"), Severity.MAJOR},
-                {"6.9",  Double.valueOf("-1"),  Double.valueOf("2.0"), Severity.MAJOR},
-                {"4.0",  Double.valueOf("-1"),  Double.valueOf("2.0"), Severity.MAJOR},
-                {"3.9",  Double.valueOf("-1"),  Double.valueOf("2.0"), Severity.MAJOR},
-                {"1.9",  Double.valueOf("-1"),  Double.valueOf("2.0"), Severity.MINOR},
-                {"0.0",  Double.valueOf("-1"),  Double.valueOf("2.0"), Severity.MINOR},
-                
-	            // custom, critical and major deactivated
-                {"10.0", Double.valueOf("-1"),  Double.valueOf("-1"),  Severity.MINOR},
-                {"7.0",  Double.valueOf("-1"),  Double.valueOf("-1"),  Severity.MINOR},
-                {"6.9",  Double.valueOf("-1"),  Double.valueOf("-1"),  Severity.MINOR},
-                {"4.0",  Double.valueOf("-1"),  Double.valueOf("-1"),  Severity.MINOR},
-                {"3.9",  Double.valueOf("-1"),  Double.valueOf("-1"),  Severity.MINOR},
-                {"1.9",  Double.valueOf("-1"),  Double.valueOf("-1"),  Severity.MINOR},
-                {"0.0",  Double.valueOf("-1"),  Double.valueOf("-1"),  Severity.MINOR}
+                // defaults
+                {"10.0", Double.valueOf("7.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"7.0",  Double.valueOf("7.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"6.9",  Double.valueOf("7.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"4.0",  Double.valueOf("7.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"3.9",  Double.valueOf("7.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.MINOR},
+                {"0.0",  Double.valueOf("7.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.MINOR},
+
+                // custom
+                {"10.0", Double.valueOf("5.0"), Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.CRITICAL},
+                {"7.0",  Double.valueOf("5.0"), Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.CRITICAL},
+                {"6.9",  Double.valueOf("5.0"), Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.CRITICAL},
+                {"4.0",  Double.valueOf("5.0"), Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MAJOR},
+                {"3.9",  Double.valueOf("5.0"), Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MAJOR},
+                {"1.9",  Double.valueOf("5.0"), Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MINOR},
+                {"0.0",  Double.valueOf("5.0"), Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.INFO},
+
+                // custom, critical deactivated
+                {"10.0", Double.valueOf("-1"),  Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MAJOR},
+                {"7.0",  Double.valueOf("-1"),  Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MAJOR},
+                {"6.9",  Double.valueOf("-1"),  Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MAJOR},
+                {"4.0",  Double.valueOf("-1"),  Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MAJOR},
+                {"3.9",  Double.valueOf("-1"),  Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MAJOR},
+                {"1.9",  Double.valueOf("-1"),  Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.MINOR},
+                {"0.0",  Double.valueOf("-1"),  Double.valueOf("2.0"), Double.valueOf("1.0"), Severity.INFO},
+
+                // custom, critical and major deactivated
+                {"10.0", Double.valueOf("-1"),  Double.valueOf("-1"), Double.valueOf("1.0"), Severity.MINOR},
+                {"7.0",  Double.valueOf("-1"),  Double.valueOf("-1"), Double.valueOf("1.0"), Severity.MINOR},
+                {"6.9",  Double.valueOf("-1"),  Double.valueOf("-1"), Double.valueOf("1.0"), Severity.MINOR},
+                {"4.0",  Double.valueOf("-1"),  Double.valueOf("-1"), Double.valueOf("1.0"), Severity.MINOR},
+                {"3.9",  Double.valueOf("-1"),  Double.valueOf("-1"), Double.valueOf("1.0"), Severity.MINOR},
+                {"1.9",  Double.valueOf("-1"),  Double.valueOf("-1"), Double.valueOf("1.0"), Severity.MINOR},
+                {"0.0",  Double.valueOf("-1"),  Double.valueOf("-1"), Double.valueOf("1.0"), Severity.INFO},
+
+                // all vulnerabilites are critical
+                {"10.0", Double.valueOf("0.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"7.0",  Double.valueOf("0.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"6.9",  Double.valueOf("0.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"4.0",  Double.valueOf("0.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"3.9",  Double.valueOf("0.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"1.9",  Double.valueOf("0.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+                {"0.0",  Double.valueOf("0.0"), Double.valueOf("4.0"), Double.valueOf("0.0"), Severity.CRITICAL},
+
+                // all vulnerabilites are MAJOR, critical is deactivated
+                {"10.0", Double.valueOf("-1"), Double.valueOf("0.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"7.0",  Double.valueOf("-1"), Double.valueOf("0.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"6.9",  Double.valueOf("-1"), Double.valueOf("0.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"4.0",  Double.valueOf("-1"), Double.valueOf("0.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"3.9",  Double.valueOf("-1"), Double.valueOf("0.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"1.9",  Double.valueOf("-1"), Double.valueOf("0.0"), Double.valueOf("0.0"), Severity.MAJOR},
+                {"0.0",  Double.valueOf("-1"), Double.valueOf("0.0"), Double.valueOf("0.0"), Severity.MAJOR},
+
+                // all vulnerabilites are MINOR, critical and major are deactivated
+                {"10.0", Double.valueOf("-1"), Double.valueOf("-1"), Double.valueOf("0.0"), Severity.MINOR},
+                {"7.0",  Double.valueOf("-1"), Double.valueOf("-1"), Double.valueOf("0.0"), Severity.MINOR},
+                {"6.9",  Double.valueOf("-1"), Double.valueOf("-1"), Double.valueOf("0.0"), Severity.MINOR},
+                {"4.0",  Double.valueOf("-1"), Double.valueOf("-1"), Double.valueOf("0.0"), Severity.MINOR},
+                {"3.9",  Double.valueOf("-1"), Double.valueOf("-1"), Double.valueOf("0.0"), Severity.MINOR},
+                {"1.9",  Double.valueOf("-1"), Double.valueOf("-1"), Double.valueOf("0.0"), Severity.MINOR},
+                {"0.0",  Double.valueOf("-1"), Double.valueOf("-1"), Double.valueOf("0.0"), Severity.MINOR},
+
+                // all vulnerabilities are INFO, critical, major and minor deactivated
+                {"10.0", Double.valueOf("-1"),  Double.valueOf("-1"),  Double.valueOf("-1"), Severity.INFO},
+                {"7.0",  Double.valueOf("-1"),  Double.valueOf("-1"),  Double.valueOf("-1"), Severity.INFO},
+                {"6.9",  Double.valueOf("-1"),  Double.valueOf("-1"),  Double.valueOf("-1"), Severity.INFO},
+                {"4.0",  Double.valueOf("-1"),  Double.valueOf("-1"),  Double.valueOf("-1"), Severity.INFO},
+                {"3.9",  Double.valueOf("-1"),  Double.valueOf("-1"),  Double.valueOf("-1"), Severity.INFO},
+                {"1.9",  Double.valueOf("-1"),  Double.valueOf("-1"),  Double.valueOf("-1"), Severity.INFO},
+                {"0.0",  Double.valueOf("-1"),  Double.valueOf("-1"),  Double.valueOf("-1"), Severity.INFO}
         });
     }
 
     @Test
     public void testCvssToSonarQubeSeverity() {
-        assertThat(DependencyCheckUtils.cvssToSonarQubeSeverity(this.cvssSeverity, this.critical, this.major)).isEqualTo(this.expectedSeverity);
+        assertThat(DependencyCheckUtils.cvssToSonarQubeSeverity(this.cvssSeverity, this.critical, this.major, this.minor)).isEqualTo(this.expectedSeverity);
     }
 
 }


### PR DESCRIPTION
Severity `minor` is now configurable and can be deactivated, the same way `critical` and `major` can.

This was required so we can be informed about vulnerabilities without being locked because of Quality Gate (severity = `INFO` if the above mentioned are deactivated). We can then work on reported problems in larger time frame.

Once these specific technical debt is fixed we can reset to default values.

2a72c7b allows 0 as a value so we can set all reported vulnerabilities to a chosen severity.